### PR TITLE
C and T bit description updates

### DIFF
--- a/draft-ietf-idr-wide-bgp-communities.xml
+++ b/draft-ietf-idr-wide-bgp-communities.xml
@@ -712,7 +712,7 @@ header itself plus total length of 4 octet values.</t>
 
 <section title="BGP Community Container Atoms" anchor="atoms">
 
-<t>Some types of BGP Community Contaners, for example BGP Wide Communities,
+<t>Some types of BGP Community Containers, for example BGP Wide Communities,
 will act on and hence need to encode some distinct Atoms of data. Use of
 Atoms is solely subject to definition of the specific BGP Container type.  
 Atoms are encoded as TLVs, where each TLV has the following format:</t>

--- a/draft-ietf-idr-wide-bgp-communities.xml
+++ b/draft-ietf-idr-wide-bgp-communities.xml
@@ -374,7 +374,7 @@ registration policies.</t>
 
 <t>Flags are defined globally and apply to all container types.</t> 
 
-<t>Bit 0 (T bit) Transitivity bit:
+<t>The T (Transitivity) bit:
 <list><t>
 When not set (value 0), the community in 
 the container is transitive across AS boundaries, but not across an
@@ -386,7 +386,7 @@ arbitrary set of connected ASes, possibly under control of a single entity.
 How such an administrative boundary is determined is out of scope of this
 document.</t>
 </list></t> 
-<t>Bit 1 (C bit) Confederation bit:
+<t>The C (Confederation) bit:
 <list><t>The confederation bit is used to manage the propagation 
 scope of a given BGP Wide Community across confederation boundaries.</t>
 <t>When not set (value 0) community 


### PR DESCRIPTION
The common header is defined as:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|             Type              |    Flags  |C|T|   Reserved    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            Length             |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

The text then describes the T bit as bit 0 and the C bit as bit 1. 

I'm assuming this is a carryover from an older version of the draft, so I'm removing the "bit 0 and bit 1 references.